### PR TITLE
fix: unpack survey_data when calling citric.add_survey

### DIFF
--- a/main.py
+++ b/main.py
@@ -369,7 +369,7 @@ def add_survey(survey_data: dict[str, Any]) -> int:
         survey_data: The survey data.
     """
     with get_client() as client:
-        return client.add_survey(survey_data)
+        return client.add_survey(**survey_data)
 
 
 @mcp.tool()


### PR DESCRIPTION
The citric client expects the parameters to be unpacked when calling add_survey: https://citric.readthedocs.io/en/1.4.0/_api/citric/index.html#citric.Client.add_survey

One line change to unpack the survey_data dict.